### PR TITLE
Develop: Add late parsed variables like {member_id}

### DIFF
--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Switchee v2.0.2 (beta)
+Switchee v2.0.3 (beta)
 
 
 Switch/case control structure for templates

--- a/README
+++ b/README
@@ -39,7 +39,7 @@ HOW TO USE
 		
 		{!-- you can also nest Switchee by leaving off the 'exp:' in nested tags : --}
 		{switchee variable="{another_variable_to_test}" parse="inward"}
-			{case value="value1" default="Yes"}
+			{case value="value1"}
 				nested content to show
 			{/case}
 		{/switchee}	

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Switchee v2.0.4 (beta)
+Switchee v2.0.5 (beta)
 
 
 Switch/case control structure for templates

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Switchee v2.0.1 (beta)
+Switchee v2.0.2 (beta)
 
 
 Switch/case control structure for templates

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Switchee v2.0.3 (beta)
+Switchee v2.0.4 (beta)
 
 
 Switch/case control structure for templates

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Switchee v2.0 (beta)
+Switchee v2.0.1 (beta)
 
 
 Switch/case control structure for templates

--- a/README
+++ b/README
@@ -1,4 +1,4 @@
-Switchee v2.0.5 (beta)
+Switchee v2.0.6 (beta)
 
 
 Switch/case control structure for templates

--- a/README
+++ b/README
@@ -1,3 +1,5 @@
+Switchee v2.0 (beta)
+
 Switch/case control structure for templates
 -------------------------------------------
 
@@ -11,4 +13,61 @@ As Switchee is a tag we can use parse=“inward” to ensure that unmatched cond
 * Supports empty string matches represesnted by ‘’ or “”
 
 Developers: 
-If you wish to develop the EE 1.6.x compatible version of this plugin, please use the 1.6 branch. Use the master branch for EE 2.x.
+Th
+
+-------------------
+HOW TO USE
+-------------------
+{exp:switchee variable = "{variable_to_test}" parse="inward"}
+	
+	{case value="value1|value2"}
+		Content to show
+	{/case}
+	
+	{case value="value3" default="Yes"}
+		Content to show
+	{/case}
+	
+	{case value="#^P(\d+)$#|''"}
+		Use regular expressions enclosed by hashes #regex#
+		Be careful to encode the following reserved characters as follows:
+		{ = &#123;
+		| = &#124;
+		} = &#125;
+		Use '' to represent an empty string
+	{/case}
+	
+	{case value="value4" default="Yes"}	
+		
+		{!-- you can also nest Switchee by leaving off the 'exp:' in nested tags : --}
+		{switchee variable="{another_variable_to_test}" parse="inward"}
+			{case value="value1" default="Yes"}
+				nested content to show
+			{/case}
+		{/switchee}	
+		
+	{/case}
+	
+{/exp:switchee}
+
+How to support no_result blocks inside wrapped tags:
+
+{if switchee_no_results}
+	{redirect="channel/noresult"}
+{/if}
+
+GET and POST globals can be evaluated by prefixing with get: or post:, e.g.:
+{exp:switchee variable = "post:my_var" parse="inward"}
+
+Any global variable can be evaluated by prefixing with global:, e.g.:
+{exp:switchee variable = "global:my_var" parse="inward"}
+
+Any Stash module variable can be evaluated by prefixing with stash:, e.g.:
+{exp:switchee variable = "stash:my_var" parse="inward"}
+
+	<?php
+		$buffer = ob_get_contents();
+		ob_end_clean();
+		return $buffer;
+	}	
+}

--- a/README
+++ b/README
@@ -1,5 +1,6 @@
 Switchee v2.0 (beta)
 
+
 Switch/case control structure for templates
 -------------------------------------------
 
@@ -11,9 +12,6 @@ As Switchee is a tag we can use parse=“inward” to ensure that unmatched cond
 * Supports regular expression matching like so: #regex#
 * Multiple regular expressions separated by | can be used for one case value
 * Supports empty string matches represesnted by ‘’ or “”
-
-Developers: 
-Th
 
 -------------------
 HOW TO USE

--- a/pi.switchee.php
+++ b/pi.switchee.php
@@ -2,7 +2,7 @@
 
 $plugin_info = array(
   'pi_name' => 'Switchee',
-  'pi_version' =>'2.0.4',
+  'pi_version' =>'2.0.5',
   'pi_author' =>'Mark Croxton',
   'pi_author_url' => 'http://www.hallmark-design.co.uk/',
   'pi_description' => 'Switch/case control structure for templates',
@@ -89,7 +89,11 @@ class Switchee {
 		
 		// replace content inside nested tags with indexed placeholders, storing it in an array for later
 		// here's the tricky bit - we only match outer tags
+		/*
 		$pattern = '/{switchee(?>(?!{\/?switchee).|(?R))*{\/switchee/si';
+		*/
+		// more memory efficient version of the above...
+		$pattern = '#{switchee(?>(?:[^{]++|{(?!\/?switchee[^}]*}))+|(?R))*{\/switchee#si';
 		$tagdata = preg_replace_callback($pattern, array(get_class($this), '_placeholders'), $tagdata);
 		
 		// returns NULL on PCRE error
@@ -241,34 +245,34 @@ class Switchee {
 		// either an unsuccessful match, or a PCRE error occurred
         $pcre_err = preg_last_error();  // PHP 5.2 and above
 
-        if ($pcre_err === PREG_NO_ERROR) 
+		if ($pcre_err === PREG_NO_ERROR)
 		{
 			$this->EE->TMPL->log_item("Switchee: Successful non-match");
-        } 
+		}
 		else 
 		{
             // preg_match error :(
-            switch ($pcre_err) 
+			switch ($pcre_err) 
 			{
-                case PREG_INTERNAL_ERROR:
-                    $this->EE->TMPL->log_item("Switchee: PREG_INTERNAL_ERROR");
-                    break;
-                case PREG_BACKTRACK_LIMIT_ERROR:
-                    $this->EE->TMPL->log_item("Switchee: PREG_BACKTRACK_LIMIT_ERROR");
-                    break;
-                case PREG_RECURSION_LIMIT_ERROR:
-                    $this->EE->TMPL->log_item("Switchee: PREG_RECURSION_LIMIT_ERROR");
-                    break;
-                case PREG_BAD_UTF8_ERROR:
-                    $this->EE->TMPL->log_item("Switchee: PREG_BAD_UTF8_ERROR");
-                    break;
-                case PREG_BAD_UTF8_OFFSET_ERROR:
-                    $this->EE->TMPL->log_item("Switchee: PREG_BAD_UTF8_OFFSET_ERROR");
-                    break;
-                default:
-                    $this->EE->TMPL->log_item("Switchee: Unrecognized PREG error");
-                    break;
-            }
+			    case PREG_INTERNAL_ERROR:
+			        $this->EE->TMPL->log_item("Switchee: PREG_INTERNAL_ERROR");
+			        break;
+			    case PREG_BACKTRACK_LIMIT_ERROR:
+			        $this->EE->TMPL->log_item("Switchee: PREG_BACKTRACK_LIMIT_ERROR");
+			        break;
+			    case PREG_RECURSION_LIMIT_ERROR:
+			        $this->EE->TMPL->log_item("Switchee: PREG_RECURSION_LIMIT_ERROR");
+			        break;
+			    case PREG_BAD_UTF8_ERROR:
+			        $this->EE->TMPL->log_item("Switchee: PREG_BAD_UTF8_ERROR");
+			        break;
+			    case PREG_BAD_UTF8_OFFSET_ERROR:
+			        $this->EE->TMPL->log_item("Switchee: PREG_BAD_UTF8_OFFSET_ERROR");
+			        break;
+			    default:
+			        $this->EE->TMPL->log_item("Switchee: Unrecognized PREG error");
+			        break;
+			}
 		}
 	}
 

--- a/pi.switchee.php
+++ b/pi.switchee.php
@@ -2,7 +2,7 @@
 
 $plugin_info = array(
   'pi_name' => 'Switchee',
-  'pi_version' =>'2.0.5',
+  'pi_version' =>'2.0.6',
   'pi_author' =>'Mark Croxton',
   'pi_author_url' => 'http://www.hallmark-design.co.uk/',
   'pi_description' => 'Switch/case control structure for templates',
@@ -27,8 +27,8 @@ class Switchee {
 	{
 		$this->EE =& get_instance();
 		
-		// reduce the PCRE default recursion limit to a safe level so that if a stack overflow
-		// occurs a PCRE error is generated rather than a server crash (segmentation fault)
+		// reduce the PCRE default recursion limit to a safe level to prevent a server crash 
+		// (segmentation fault) when the available stack is exhausted before recursion limit reached
 		// Apache *nix executable stack size is 8Mb, so safe size is 16777
 		// Apache Win32 executable stack size is 256Kb, so safe size is 524
 		ini_set('pcre.recursion_limit', '16777');
@@ -92,10 +92,10 @@ class Switchee {
 		/*
 		$pattern = '/{switchee(?>(?!{\/?switchee).|(?R))*{\/switchee/si';
 		*/
-		// more memory efficient version of the above...
+		// more memory efficient version of the above...	
 		$pattern = '#{switchee(?>(?:[^{]++|{(?!\/?switchee[^}]*}))+|(?R))*{\/switchee#si';
 		$tagdata = preg_replace_callback($pattern, array(get_class($this), '_placeholders'), $tagdata);
-		
+	
 		// returns NULL on PCRE error
 		if ($tagdata === NULL && $debug)
 		{
@@ -213,7 +213,7 @@ class Switchee {
 			// convert the outer shell of {switchee} tag pairs to plugin tags {exp:switchee}
 			// now we can do this all over again...
 			$val = preg_replace( array('/^{switchee/i', '/{\/switchee$/i'), array('{exp:switchee', '{/exp:switchee'), $val);
-			$this->return_data = str_replace('[_'.__CLASS__.'_'.($index+1).']', $val, $this->return_data);
+			$this->return_data = str_replace('{[_'.__CLASS__.'_'.($index+1).']', $val, $this->return_data);
 		}
 	}
 	
@@ -229,7 +229,7 @@ class Switchee {
 	private function _placeholders($matches)
 	{
 		$this->_ph[] = $matches[0];
-		return '[_'.__CLASS__.'_'.count($this->_ph).']';
+		return '{[_'.__CLASS__.'_'.count($this->_ph).']';
 	}	
 	
 	/** 

--- a/pi.switchee.php
+++ b/pi.switchee.php
@@ -43,6 +43,21 @@ class Switchee {
 		// the variable we want to find
 		$var = $this->EE->TMPL->fetch_param('variable') ? $this->EE->TMPL->fetch_param('variable') : '';
 		
+		// add late parsed variables like logged_in and member_id that are already available in session
+		switch($var)
+		{
+			case '{logged_in}':
+			case '{member_id}':
+			case '{logged_in_member_id}':
+				$var = $this->EE->session->userdata('member_id');
+				break;
+			case '{group_id}':
+			case '{logged_in_group_id}':
+			case '{member_group}':
+				$var = $this->EE->session->userdata('group_id');
+				break;
+		}
+
 		// debug?
 		$debug = (bool) preg_match('/1|on|yes|y/i', $this->EE->TMPL->fetch_param('debug'));	
 		

--- a/pi.switchee.php
+++ b/pi.switchee.php
@@ -2,7 +2,7 @@
 
 $plugin_info = array(
   'pi_name' => 'Switchee',
-  'pi_version' =>'2.0',
+  'pi_version' =>'2.0.1',
   'pi_author' =>'Mark Croxton',
   'pi_author_url' => 'http://www.hallmark-design.co.uk/',
   'pi_description' => 'Switch/case control structure for templates',
@@ -149,8 +149,7 @@ class Switchee {
 							preg_match($pattern, $tagdata, $matches);
 							$this->return_data = @$matches[1];
 							break 2;
-						}	
-						
+						}
 					}
 				}
 				
@@ -175,7 +174,7 @@ class Switchee {
 		{
 			// convert the outer shell of {switchee} tag pairs to plugin tags {exp:switchee}
 			// now we can do this all over again...
-			$val = str_replace( array('{switchee', '{/switchee'), array('{exp:switchee', '{/exp:switchee'), $val );
+			$val = preg_replace( array('/^{switchee/', '/{\/switchee$/'), array('{exp:switchee', '{/exp:switchee'), $val);
 			$this->return_data = str_replace('[_'.__CLASS__.'_'.($index+1).']', $val, $this->return_data);
 		}
 	}

--- a/pi.switchee.php
+++ b/pi.switchee.php
@@ -2,7 +2,7 @@
 
 $plugin_info = array(
   'pi_name' => 'Switchee',
-  'pi_version' =>'2.0.1',
+  'pi_version' =>'2.0.2',
   'pi_author' =>'Mark Croxton',
   'pi_author_url' => 'http://www.hallmark-design.co.uk/',
   'pi_description' => 'Switch/case control structure for templates',
@@ -42,25 +42,10 @@ class Switchee {
 		}
 		
 		// register variables created by Stash
-		if (strncmp($var, 'stash:', 6) == 0)
+		if (strncmp($var, 'stash:', 6) == 0 && class_exists('Stash'))
 		{
-			if (isset($this->EE->session->cache['stash']))
-			{
-				$var = substr($var, 6);
-				if (array_key_exists($var, $this->EE->session->cache['stash']))
-				{
-					// houston, we have a value
-					$var = $this->EE->session->cache['stash'][$var];
-				}
-				else
-				{
-					$var = '';
-				}
-			}
-			else
-			{
-				$var = '';
-			}
+			$var = substr($var, 6);
+			$var = stash::get($var);
 		}
 		
 		// register global vars
@@ -174,7 +159,7 @@ class Switchee {
 		{
 			// convert the outer shell of {switchee} tag pairs to plugin tags {exp:switchee}
 			// now we can do this all over again...
-			$val = preg_replace( array('/^{switchee/', '/{\/switchee$/'), array('{exp:switchee', '{/exp:switchee'), $val);
+			$val = preg_replace( array('/^{switchee/i', '/{\/switchee$/i'), array('{exp:switchee', '{/exp:switchee'), $val);
 			$this->return_data = str_replace('[_'.__CLASS__.'_'.($index+1).']', $val, $this->return_data);
 		}
 	}


### PR DESCRIPTION
```
{exp:switchee variable="{segment_3}"}
    {case value="x"}
         {!-- Normally member data is parsed late in the template, like logged_in or member_id --}
         {switchee variable="{member_id}"}
              {case value="0"}
                  Not logged in
              {/case}
              {case default="yes"}
                  You are logged in
              {/case}
         {/switchee}
    {/case}
    {case value="y"}
         Blah
    {/case}
{/exp:switchee}
```
