### PR TITLE
Match all functionality.

### DIFF
--- a/pi.switchee.php
+++ b/pi.switchee.php
@@ -2,7 +2,7 @@
 
 $plugin_info = array(
   'pi_name' => 'Switchee',
-  'pi_version' =>'2.0.6',
+  'pi_version' =>'2.1',
   'pi_author' =>'Mark Croxton',
   'pi_author_url' => 'http://www.hallmark-design.co.uk/',
   'pi_description' => 'Switch/case control structure for templates',


### PR DESCRIPTION
Added the ability to optionally return the results of **all** matching cases, instead of just the first matching case, by adding a `match="all"` parameter. This allows for amazing flexibility without having to create several different tags.

Example:

```
{exp:switchee variable="{page_type}" match="all" parse="inward"}
    {case value="section_landing|section_sub_page"}
        <p>This will show for landing and sub pages.</p>
    {/case}

    {case value="section_landing"}
        <p>This will also show if we're on landing pages.</p>
    {/case}

    {case value="section_sub_page"}
        <p>This will also show if we're on sub pages.</p>
    {/case}

    {case default="yes"}
        <p>This will still work as expected if no case is matched.</p>
    {/case}
{/exp:switchee}
```
